### PR TITLE
UGC-4131 | Unbreak extension

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.phan/issue-baseline.php linguist-generated

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,77 @@
+name: PHPUnit / PHPCS / Phan
+on:
+  pull_request:
+    branches: '**'
+
+  push:
+    branches: [ master, REL1_39 ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        php_version: ['8.0']
+        mw: ['REL1_39']
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php_version }}
+          # We don't run any coverage, so we should set this parameter to none
+          # as this will disable xdebug which slows all processes significantly
+          coverage: none
+          extensions: ast
+      - uses: actions/checkout@v3
+
+      - name: Checkout Mediawiki
+        uses: actions/checkout@v3
+        with:
+          repository: wikimedia/mediawiki
+          ref: ${{ matrix.mw }}
+
+      - name: Checkout UsingData extension
+        uses: actions/checkout@v3
+        with:
+          path: extensions/UsingData
+
+      - name: Cache UsingData composer dependencies
+        id: composer-cache
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-v3-${{ hashFiles('extensions/UsingData/composer.lock') }}
+
+      - name: Install UsingData composer dependencies
+        working-directory: ./extensions/UsingData
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run PHPCS and minus-x
+        working-directory: ./extensions/UsingData
+        run: composer test
+
+      - name: Run Phan static analysis
+        working-directory: ./extensions/UsingData
+        run: vendor/bin/phan -d . --long-progress-bar --load-baseline .phan/issue-baseline.php
+
+      - name: Start MySQL
+        run: sudo systemctl start mysql.service
+
+      - name: Install MediaWiki composer dependencies
+        run: composer update --prefer-dist --no-progress
+
+      - name: Install & configure MediaWiki
+        run: |
+          php maintenance/install.php --dbtype mysql --dbuser root --dbpass root --pass TestPassword testwiki TestAdmin
+
+          echo 'error_reporting( E_ALL | E_STRICT );' >> LocalSettings.php
+          echo 'ini_set( "display_errors", 1 );' >> LocalSettings.php
+          echo '$wgShowExceptionDetails = true;' >> LocalSettings.php
+          echo '$wgShowDBErrorBacktrace = true;' >> LocalSettings.php
+          echo '$wgDevelopmentWarnings = true;' >> LocalSettings.php
+
+          echo 'wfLoadExtension( "'UsingData'" );' >> LocalSettings.php
+
+      - name: Run parser tests
+        run: php tests/parser/parserTests.php --file extensions/UsingData/tests/parser/parserTests.txt

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -1,0 +1,7 @@
+<?php
+
+$config = require __DIR__ . '/../vendor/mediawiki/mediawiki-phan-config/src/config.php';
+
+$config['minimum_target_php_version'] = '8.0.28';
+
+return $config;

--- a/.phan/issue-baseline.php
+++ b/.phan/issue-baseline.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This is an automatically generated baseline for Phan issues.
+ * When Phan is invoked with --load-baseline=path/to/baseline.php,
+ * The pre-existing issues listed in this file won't be emitted.
+ *
+ * This file can be updated by invoking Phan with --save-baseline=path/to/baseline.php
+ * (can be combined with --load-baseline)
+ */
+return [
+	// # Issue statistics:
+	// PhanUndeclaredProperty : 15+ occurrences
+	// PhanTypeMismatchReturn : 5 occurrences
+	// SecurityCheck-XSS : 3 occurrences
+	// PhanCoalescingNeverNull : 1 occurrence
+	// PhanTypeMismatchArgumentNullable : 1 occurrence
+	// PhanTypeMismatchReturnProbablyReal : 1 occurrence
+	// PhanUndeclaredMethod : 1 occurrence
+
+	// Currently, file_suppressions and directory_suppressions are the only supported suppressions
+	'file_suppressions' => [
+		'src/UsingDataHooks.php' => [ 'PhanCoalescingNeverNull', 'PhanTypeMismatchArgumentNullable', 'PhanUndeclaredProperty', 'SecurityCheck-XSS' ],
+		'src/UsingDataPPFrameDOM.php' => [ 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty' ],
+	],
+	// 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
+	// (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)
+];

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,7 +1,18 @@
 <?xml version="1.0"?>
-<ruleset name="MediaWiki">
-    <rule ref="./vendor/hydrawiki/hydrawiki-codesniffer/HydraWiki" />
-    <file>.</file>
-    <arg name="encoding" value="utf8"/>
-    <arg name="extensions" value="php"/>
+<ruleset>
+	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingParamTag" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationPublic" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingReturn" />
+
+		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationPublic" />
+
+		<exclude name="MediaWiki.WhiteSpace.SpaceBeforeSingleLineComment.NewLineComment" />
+	</rule>
+	<file>.</file>
+	<arg name="extensions" value="php"/>
+	<arg name="encoding" value="UTF-8"/>
+
+	<!-- This is a generated file -->
+	<exclude-pattern>.phan/issue-baseline.php</exclude-pattern>
 </ruleset>

--- a/UsingData.i18n.magic.php
+++ b/UsingData.i18n.magic.php
@@ -2,10 +2,10 @@
 $magicWords = [];
 
 $magicWords['en'] = [
-	'data'			=> [0, 'data'],
-	'using'			=> [0, 'using'],
-	'usingarg'		=> [0, 'usingarg'],
-	'ancestorname'	=> [0, 'ancestorname'],
-	'selfname'		=> [0, 'selfname'],
-	'parentname'	=> [0, 'parentname', 'ancestorname']
+	'data'			=> [ 0, 'data' ],
+	'using'			=> [ 0, 'using' ],
+	'usingarg'		=> [ 0, 'usingarg' ],
+	'ancestorname'	=> [ 0, 'ancestorname' ],
+	'selfname'		=> [ 0, 'selfname' ],
+	'parentname'	=> [ 0, 'parentname', 'ancestorname' ]
 ];

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+	"name": "wikia/default-links",
+	"description": "Allows articles to specify formatting of incoming links",
+	"type": "mediawiki-extension",
+	"require-dev": {
+		"mediawiki/mediawiki-codesniffer": "^41.0",
+		"mediawiki/mediawiki-phan-config": "^0.12.0",
+		"mediawiki/minus-x": "^1.1"
+	},
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"php": ">=8.0"
+	},
+	"scripts": {
+		"phpcs": "phpcs -sp",
+		"test": [
+			"minus-x check .",
+			"@phpcs"
+		],
+		"phan": "phan -d . --long-progress-bar"
+	}
+}

--- a/extension.json
+++ b/extension.json
@@ -29,7 +29,8 @@
 		"BeforeParserFetchTemplateRevisionRecord": "UsingDataHookHandler",
 		"GetMagicVariableIDs": "UsingDataHookHandler",
 		"ParserFirstCallInit": "UsingDataHookHandler",
-		"ParserGetVariableValueSwitch": "UsingDataHookHandler"
+		"ParserGetVariableValueSwitch": "UsingDataHookHandler",
+		"ParserClearState": "UsingDataHookHandler"
 	},
 	"manifest_version": 1
 }

--- a/src/UsingDataHooks.php
+++ b/src/UsingDataHooks.php
@@ -5,6 +5,7 @@ namespace UsingData;
 use Config;
 use MediaWiki\Hook\BeforeParserFetchTemplateRevisionRecordHook;
 use MediaWiki\Hook\GetMagicVariableIDsHook;
+use MediaWiki\Hook\ParserClearStateHook;
 use MediaWiki\Hook\ParserFirstCallInitHook;
 use MediaWiki\Hook\ParserGetVariableValueSwitchHook;
 use MediaWiki\Linker\LinkTarget;
@@ -17,7 +18,8 @@ class UsingDataHooks implements
 	ParserFirstCallInitHook,
 	GetMagicVariableIDsHook,
 	BeforeParserFetchTemplateRevisionRecordHook,
-	ParserGetVariableValueSwitchHook
+	ParserGetVariableValueSwitchHook,
+	ParserClearStateHook
 {
 	public function __construct(
 		private Config $config,
@@ -51,7 +53,8 @@ class UsingDataHooks implements
 		if (
 			(
 				$sourcePage === '' ||
-				Title::castFromPageReference( $parser->getPage() )->getPrefixedText()
+				$sourcePage === Title::castFromPageReference( $parser->getPage() )
+					->getPrefixedText()
 			) && !$parser->getOptions()->getIsSectionPreview() ) {
 			return $this->dataFrames[$sourcePage];
 		}
@@ -61,24 +64,27 @@ class UsingDataHooks implements
 			$this->dataFrames[$fTitle->getPrefixedText()] = $this->dataFrames[$sourcePage];
 		}
 
-		global $wgHooks;
 		if ( is_string( $text ) && $text != '' ) {
 			$this->searchingForData = true;
-			$clearStateHooks = $wgHooks['ParserClearState'];
-			// Other extensions tend to assume the hook is only called by wgParser and reset internal state
-			$wgHooks['ParserClearState'] = [];
+
 			$subParser = clone $parser;
 			$subParser->preprocess( $text, $fTitle, clone $parser->getOptions() );
-			// We might've blocked access to templates while preprocessing; should not be cached
-			$subParser->clearState();
-			$subParser->getOutput()->setText( $parser->getOutput()->getText() );
-			$wgHooks['ParserClearState'] = empty( $wgHooks['ParserClearState'] )
-				? $clearStateHooks
-				: array_merge( $clearStateHooks, $wgHooks['ParserClearState'] );
+
 			$parser->mPPNodeCount += $subParser->mPPNodeCount;
+
 			$this->searchingForData = false;
+
 		}
 		return $this->dataFrames[$sourcePage];
+	}
+
+	/**
+	 * Reset handler state between parse() calls.
+	 * @param Parser $parser
+	 * @return void
+	 */
+	public function onParserClearState( $parser ): void {
+		$this->dataFrames = [];
 	}
 
 	/** Returns the page title of the $depth ancestor of $frame; empty string if invalid */

--- a/tests/parser/parserTests.txt
+++ b/tests/parser/parserTests.txt
@@ -1,0 +1,80 @@
+!! options
+version=2
+!! end
+
+!! article
+Template:DataWrapper
+!! text
+<div id="tmpl-data-wrapper"><div id="prop-one">{{{prop_one}}}</div><div id="prop-two">{{{prop_two}}}</div></div>
+!! endarticle
+
+!! article
+Template:OtherTemplate
+!! text
+{{{prop_one}}}
+!! endarticle
+
+!! article
+Template:TemplateUsingData
+!! text
+<using page="{{{1}}}">{{{prop_one}}}</using>
+!! endarticle
+
+!! article
+Example Item
+!! text
+{{#data:DataWrapper|prop_one=Test Prop One|prop_two=Test Prop Two}}
+!! endarticle
+
+!! test
+#data parser function
+!! options
+title=[[Test Item]]
+!! wikitext
+{{#data:DataWrapper|prop_one=Foo|prop_two=Bar}}
+!! html
+<div id="tmpl-data-wrapper"><div id="prop-one">Foo</div><div id="prop-two">Bar</div></div>
+!! end
+
+!! test
+#using parser function
+!! wikitext
+{{#using:Example Item|DataWrapper}}
+!! html
+<div id="tmpl-data-wrapper"><div id="prop-one">Test Prop One</div><div id="prop-two">Test Prop Two</div></div>
+!! end
+
+!! test
+#using parser function with parameter override
+!! wikitext
+{{#using:Example Item|DataWrapper|prop_one=Overridden Prop One}}
+!! html
+<div id="tmpl-data-wrapper"><div id="prop-one">Overridden Prop One</div><div id="prop-two">Test Prop Two</div></div>
+!! end
+
+!! test
+#using parser function with template override
+!! wikitext
+{{#using:Example Item|OtherTemplate}}
+!! html
+<p>Test Prop One
+</p>
+!! end
+
+!! test
+#using parser tag
+!! wikitext
+<using page="Example Item">{{{prop_one}}}</using>
+!! html
+<p>Test Prop One
+</p>
+!! end
+
+!! test
+transcluded #using parser tag
+!! wikitext
+{{TemplateUsingData|Example Item}}
+!! html
+<p>Test Prop One
+</p>
+!! end


### PR DESCRIPTION
In 50e64e5, the UsingData extension was refactored as part of upgrade work. This sadly broke the $sourcePage check in `getDataFrame`, causing it to render no data in the using tag and parser function. So, restore the original, working, condition, and add parser tests for the logic.

Reproducing the issue in parser tests proved a bit nettlesome as the tests were falsely passing at first. This is because the UsingData parser hook handler instance uses shared state to store data frame instances, and this instance is kept alive and reused by all parser tests, causing data to be shared between tests that would not be shared between actual page parses. As such, introduce a ParserClearState handler to reset internal handler state between full parses to make the tests better reflect the behavior in real parsing. This in turn required removing the clearState() call and hooks manipulation in getDataFrame(), as it would also reset our clearState() handler. Given that direct manipulation of $wgHooks is deprecated as of MediaWiki 1.40 and clearing the set of handlers for a hook is only allowed in tests going forward, this is something we'd need to do sooner than later anyways.