### PR TITLE
Declare UsingDataPPFrameDOM::$args

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
 	"description": "Allows articles to specify formatting of incoming links",
 	"type": "mediawiki-extension",
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "^41.0",
-		"mediawiki/mediawiki-phan-config": "^0.12.0",
+		"mediawiki/mediawiki-codesniffer": "41.0.0",
+		"mediawiki/mediawiki-phan-config": "0.12.0",
 		"mediawiki/minus-x": "^1.1"
 	},
 	"license": "GPL-2.0-or-later",

--- a/src/UsingDataPPFrameDOM.php
+++ b/src/UsingDataPPFrameDOM.php
@@ -1,6 +1,7 @@
 <?php
 
 class UsingDataPPFrameDOM extends PPFrame_Hash {
+	public $args;
 	public $parent; // Parent frame (either from #using or #data, providing a parser if needed), data source title
 	public $sourcePage;
 	public $knownFragments = []; // Specifies which fragments have been declared


### PR DESCRIPTION
Otherwise its usage as a dynamic property raises warnings on PHP 8.2.